### PR TITLE
Adding links to docs and other sites

### DIFF
--- a/content.en/_index.md
+++ b/content.en/_index.md
@@ -7,7 +7,7 @@ type: docs
 
 The Protocol Benchmarking & Optimization Team (ProbeLab) is on a mission to measure the performance of Web3.0 network protocols, benchmark protocols against target performance milestones and propose improvements to their core design principles.
 
-We focus on understanding the mechanics of internal network protocols, as well as how they interact with other parts of the system. Our expertise lies in network-layer protocols, and we are particularly active in the IPFS and filecoin space, though our work is not limited to that. We dive deep into the protocol as an independent entity and investigate the exogenous factors that influence its performance.
+We focus on understanding the mechanics of internal network protocols, as well as how they interact with other parts of the system. Our expertise lies in network-layer protocols, and we are particularly active in the [IPFS](https://ipfs.io) and [Filecoin](https://filecoin.io) space, though our work is not limited to that. We dive deep into the protocol as an independent entity and investigate the exogenous factors that influence its performance.
 
 Our team specializes in cross-protocol interoperation and network architecture, works to identify potential bottlenecks and inefficiencies in the system and provide solutions, accordingly.
 

--- a/content.en/contact/_index.md
+++ b/content.en/contact/_index.md
@@ -17,8 +17,8 @@ This site is maintained by the ProbeLab team @ Protocol Labs.
 
 If you spot inconsistencies, inaccurate claims, want to request additional results, or want to collaborate with us, please reach out using any of the following channels:
 
-- The IPFS Discussion forum, under the “Testing & Experiments” category and the “Measurements” tab.
-- The #probe-lab channel in IPFS Discord, or Filecoin Slack (bridged channel).
-- The team’s email: probelab@protocol.ai 
+- The [IPFS Discussion forum](https://discuss.ipfs.tech/c/testing-and-experiments/measurements/39), under the “Testing & Experiments” category and the “Measurements” tab.
+- The #probe-lab channel in IPFS Discord [[invite link](https://discord.gg/ipfs)], or Filecoin Slack [[invite link](https://filecoin.io/slack)] (bridged channel).
+- The team’s email: probelab@protocol.ai
 
 We also hold bi-weekly Office Hours where we invite the community and our collaborators to join and bring up questions, challenges they face and topics for discussion. You can sign up through this lu.ma page: https://lu.ma/ipfs-network-measurements

--- a/content.en/howtouse/_index.md
+++ b/content.en/howtouse/_index.md
@@ -13,16 +13,16 @@ the completeness or reliability of the information presented during the preview.
 {{< /hint >}}
 
 
-This is a space where we present results from our measurement and monitoring efforts. The site, as well as the infrastructure and scripts used to produce the plots are maintained by the ProbeLab team. The results focus on the IPFS network, as well as protocols of its underlaying protocol stack (e.g., Bitswap, the libp2p DHT and libp2p more generally).
+This is a space where we present results from our measurement and monitoring efforts. The site, as well as the infrastructure and scripts used to produce the plots are maintained by the ProbeLab team @ Protocol Labs. The results focus on the IPFS network, as well as protocols of its underlaying protocol stack (e.g., Bitswap, the libp2p DHT and [libp2p](https://libp2p.io) more generally).
 
 The results presented here give an accurate view of the high-level protocol operation and occasionally dive into protocol specific parameters that are primarily of interest to protocol designers and engineers. What is different about this website is that it is not a “raw” dashboard, but instead includes description of the experiments we’re carrying out in order to produce the results. Where possible, we also make the tools used to produce the results available to the community to re-use.
 
-We do not provide commentary on the results presented on this website. Instead, discussion around results reported here is taking place at the IPFS Discussion Forum, under the “Testing & Experiments” category and the “Measurements” tab [link to category in forum]([https://discuss.ipfs.tech/c/testing-and-experiments/measurements/39](https://discuss.ipfs.tech/c/testing-and-experiments/measurements/39)). We occasionally write blogposts (primarily in the IPFS blog) and technical reports, which we link from the “News” tab on this site.
+We do not provide commentary on the results presented on this website. Instead, discussion around results reported here is taking place at the [IPFS Discussion Forum](https://discuss.ipfs.tech/), under the “Testing & Experiments” category and the “Measurements” tab. We occasionally write blogposts (primarily in the [IPFS blog](https://blog.ipfs.tech) and technical reports, which we link from the “News” tab on this site.
 
 If you spot inconsistencies, inaccurate claims, or want to request additional results, please reach out using any of the following channels:
 
-- The IPFS Discussion forum, under the “Testing & Experiments” category and the “Measurements” tab.
-- The #probe-lab channel in IPFS Discord, or Filecoin Slack (bridged channel).
+- The [IPFS Discussion forum](https://discuss.ipfs.tech/c/testing-and-experiments/measurements/39), under the “Testing & Experiments” category and the “Measurements” tab.
+- The #probe-lab channel in IPFS Discord [[invite link](https://discord.gg/ipfs)], or Filecoin Slack [[invite link](https://filecoin.io/slack)] (bridged channel).
 - The team’s email: probelab@protocol.ai
 
-We also hold bi-weekly Office Hours where we invite the community and our collaborators to join and bring up questions, challenges they face and topics for discussion. You can sign up through this lu.ma page: https://lu.ma/ipfs-network-measurements
+We also hold bi-weekly Office Hours, where we invite the community and our collaborators to join and bring up questions, challenges they face and topics for discussion. You can sign up through this lu.ma page: https://lu.ma/ipfs-network-measurements

--- a/content.en/ipfsdht/_index.md
+++ b/content.en/ipfsdht/_index.md
@@ -12,18 +12,18 @@ We strive to provide accurate and up-to-date information, but we cannot guarante
 the completeness or reliability of the information presented during the preview. 
 {{< /hint >}}
 
-One of the core components of IPFS is the Distributed Hash Table (DHT), which enables nodes to locate and retrieve content from other nodes on the network. The IPFS DHT is a distributed key-value store that maps content addresses to the nodes that are currently storing that content. It works by dividing the content address space into small, hash-based "buckets" that are distributed across the network. When a node wants to find a piece of content, it queries the DHT with the content's hash, and the DHT returns the nodes that are currently storing that content. This allows content to be located and retrieved in a decentralized, efficient, and fault-tolerant manner. The IPFS DHT is a key component of the IPFS network, and is used by many IPFS applications and tools, including IPFS itself, as well as a variety of decentralized applications and systems built on top of IPFS.
+One of the core components of IPFS is the [Distributed Hash Table (DHT)](https://docs.ipfs.tech/concepts/dht/#distributed-hash-tables-dhts), which enables nodes to locate and retrieve content from other nodes on the network. The IPFS DHT is a distributed key-value store that maps content addresses (_aka_ CIDs) to the nodes that are currently storing that content. It works by dividing the content address space into small, hash-based ["buckets"](https://docs.ipfs.tech/concepts/dht/#peer-buckets) that are distributed across the network. When a node wants to find a piece of content, it queries the DHT with the content's [CID](https://docs.ipfs.tech/concepts/content-addressing/#what-is-a-cid), and the DHT returns the nodes that are currently storing that content, in the form of [Provider Records](https://docs.ipfs.tech/concepts/dht/#provider-records). This allows content to be located and retrieved in a decentralized, efficient, and fault-tolerant manner. The IPFS DHT is a key component of the IPFS network, and is used by many IPFS implementations, tools, as well as a variety of decentralized applications and systems built on top of IPFS.
 
 ## Health
 
 As a distributed system, IPFS relies on the coordinated participation of multiple nodes and servers to function correctly. Monitoring the
 availability and long term stability of DHT servers over time can give insight into the health of the network. High churn in the network
-can make content harder to locate and lead to longer retrieval times. Measuring DHT server availability and expected lifetimes can help 
+can make content harder to locate and lead to longer [retrieval](https://docs.ipfs.tech/concepts/lifecycle/#_3-retrieval) times. Measuring [DHT server](https://docs.ipfs.tech/concepts/dht/#qualification) availability and expected lifetimes can help 
 assess the health and overall efficiency of the network.
 
 ### Availability
 
-The Nebula crawler attempts to connect to peers in the IPFS DHT periodically. When a new peer is discovered, the crawler records the start of a session of availability and extends the session length with every successful connection attempt. However, a failed connection terminates the session, and a later successful attempt starts a new session. Peers can have multiple sessions of availability during each measurement period. 
+The Nebula crawler attempts to connect to [DHT Server](https://docs.ipfs.tech/concepts/dht/#qualification) peers in the IPFS DHT periodically. When a new DHT Server peer is discovered, the crawler records the start of a session of availability and extends the session length with every successful connection attempt. However, a failed connection terminates the session, and a later successful attempt starts a new session. Peers can have multiple sessions of availability during each measurement period. 
 
 In the following, a peer is classified as "online" if it was available for at least 80% of the measurement period. If a peer was available between 40% and 80% of the period, it is considered "mostly online," while "mostly offline" indicates availability between 10% and 40% of the time. Any peer that was available for less than 10% of the period is classified as "offline."
 
@@ -37,13 +37,13 @@ In the following, a peer is classified as "online" if it was available for at le
 
 {{< plotly json="../../plots/latest/dht-peers-entering-leaving.json" height="600px" >}}
 
-This plot displays the count of unique peer IDs that joined and left the network during the measurement period. The term "entered" refers to a peer that was offline at the start of the measurement period but appeared within it and remained online throughout. The term "left" refers to a peer that was online at the start of the measurement period but went offline and did not come back online before the end of the measurement period.
+This plot displays the count of unique [Peer IDs](https://docs.ipfs.tech/concepts/glossary/#peer-id) that joined and left the network during the measurement period. The term "entered" refers to a peer that was offline at the start of the measurement period but appeared within it and remained online throughout. The term "left" refers to a DHT Server peer that was online at the start of the measurement period but went offline and did not come back online before the end of the measurement period.
 
 ## Performance
 
-Measuring the time it takes to publish and retrieve information from the IPFS DHT is crucial for understanding the network's performance and identifying areas for improvement. It allows us to assess the network's efficiency in different regions, which is essential for global-scale applications that rely on the IPFS DHT. Measuring performance across different regions helps identify potential bottlenecks and optimize content delivery. 
+Measuring the time it takes to [publish](https://docs.ipfs.tech/concepts/lifecycle/#_2-pinning) and [retrieve](https://docs.ipfs.tech/concepts/lifecycle/#_3-retrieval) information from the IPFS DHT is crucial for understanding the network's performance and identifying areas for improvement. It allows us to assess the network's efficiency in different regions, which is essential for global-scale applications that rely on the IPFS DHT. Measuring performance across different regions helps identify potential bottlenecks and optimize content delivery. 
 
-We have instrumented the following experiment to capture the DHT Lookup performance over time and from several different geographic locations.
+We have instrumented the following experiment to capture the [DHT Lookup](https://docs.ipfs.tech/concepts/dht/#lookup-algorithm) performance over time and from several different geographic locations.
 We have set up IPFS DHT Server nodes in seven (7) different geographic locations. Each node periodically publishes a unique CID and makes it known to the rest of the nodes, who subsequently request it through the DHT (acting as clients). This way we capture the entire performance spectrum of the DHT, i.e., both the DHT Publish and the Lookup performance from each location.
 In this section we present the average performance over all regions, as well as per region for both the DHT Lookup Performance and the DHT Publish Performance.
 
@@ -51,7 +51,7 @@ In this section we present the average performance over all regions, as well as 
 
 {{< plotly json="../../plots/latest/dht-lookup-performance-quartiles.json" height="250px" >}}
 
-The following plots show the distribution of timings for looking up provider records from various points across the world. 
+The following plots show the distribution of timings for looking up [provider records](https://docs.ipfs.tech/concepts/dht/#provider-records) from various points across the world. 
 
 {{< plotly json="../../plots/latest/dht-lookup-performance-overall.json" height="600px" >}}
 
@@ -77,7 +77,7 @@ Measuring participation in the IPFS DHT is crucial to understanding the health a
 
 ### Client vs Server Node Estimate
 
-The plot presented below illustrates an estimate of the number of peers that exclusively function as clients. This estimate is derived by deducting the total number of unique peer IDs observed by the bootstrap nodes, operated by Protocol Labs, from the number of unique peer IDs visited by the Nebula crawler during the same period. Additionally, the plot also shows the number of unique IP addresses observed by the Nebula crawler.
+The plot presented below illustrates an estimate of the number of peers that exclusively function as clients. This estimate is derived by deducting the total number of unique peer IDs observed by the [bootstrap nodes](https://docs.ipfs.tech/concepts/glossary/#bootstrap-node), operated by Protocol Labs, from the number of unique [Peer IDs](https://docs.ipfs.tech/concepts/glossary/#peer-id) visited by the [Nebula crawler](https://github.com/dennis-tra/nebula) during the same period. Additionally, the plot also shows the number of unique IP addresses observed by the Nebula crawler.
 
 {{< plotly json="../../plots/latest/ipfs-servers-vs-clients.json" height="400px" >}}
 
@@ -88,7 +88,7 @@ These peers act as DHT servers and record provider records pointing to content a
 
 {{< plotly json="../../plots/latest/top-dhtserver-agents.json" height="800px" >}}
 
-Note that the x-axis in the above plot is represented using a log scale, which emphasizes the relatively smaller  populations of software agents compared to the much larger use of Kubo (previously known as go-ipfs) within the DHT. 
+Note that the x-axis in the above plot is represented using a log scale, which emphasizes the relatively smaller  populations of software agents compared to the much larger use of [Kubo](https://github.com/ipfs/kubo) (previously known as go-ipfs) within the DHT. 
 
 
 ### Active Kubo Versions

--- a/content.en/ipfsgateways/_index.md
+++ b/content.en/ipfsgateways/_index.md
@@ -13,14 +13,14 @@ the completeness or reliability of the information presented during the preview.
 {{< /hint >}}
 
 
-An IPFS gateway is a web-based interface that allows users to access IPFS content using a regular web browser. The gateway acts as a bridge between the IPFS network and the traditional web, allowing users to browse and retrieve IPFS content without having to install any specialized software or run a full IPFS node.
+An [IPFS gateway](https://docs.ipfs.tech/concepts/ipfs-gateway/) is a web-based interface that allows users to access IPFS content using a regular web browser. The gateway acts as a bridge between the IPFS network and the traditional web, allowing users to browse and retrieve IPFS content without having to install any specialized software or run a full IPFS node.
 
-When a user requests content through an IPFS gateway, the gateway retrieves the content from the IPFS network (through Bitswap and/or kubo) and delivers it to the user's browser using standard web protocols such as HTTP or HTTPS. This allows users to access IPFS content in the same way they would access any other web content, with a simple URL or link. IPFS gateways are a key part of the IPFS ecosystem, as they make IPFS content accessible to a wider audience and help to bridge the gap between the traditional web and the decentralized web.
+When a user requests content through an IPFS gateway, the gateway retrieves the content from the IPFS network (through [Bitswap](https://docs.ipfs.tech/concepts/bitswap/#bitswap) and/or [kubo](https://docs.ipfs.tech/install/command-line/#install-ipfs-kubo)) and delivers it to the user's browser using standard web protocols such as HTTP or HTTPS. This allows users to access IPFS content in the same way they would access any other web content, with a simple URL or link. IPFS gateways are a key part of the IPFS ecosystem, as they make IPFS content accessible to a wider audience and help to bridge the gap between the traditional web and the decentralized web.
 
 
 IPFS gateways can be run by anyone who has access to an IPFS node, and there are many public gateways available on the internet. The following measurements are made using data from the gateway services operated by Protocol Labs.
 
-In the following plots, requests are _not_ deduplicated, i.e., if there are two requests for the same CID, they count as two requests and not one. This is what makes sense for requests. Deduplicating requests would effectively count the number of CIDs requested and not the requests themselves.
+In the following plots, requests are _not_ deduplicated, i.e., if there are two requests for the same [CID](https://docs.ipfs.tech/concepts/content-addressing/#content-identifiers-cids), they count as two requests and not one. This is what makes sense for requests. Deduplicating requests would effectively count the number of CIDs requested and not the requests themselves.
 
 
 {{< plotly json="../../plots/latest/gateway-requests-overall.json" height="600px" >}}

--- a/content.en/ipfskpi/_index.md
+++ b/content.en/ipfskpi/_index.md
@@ -13,7 +13,7 @@ the completeness or reliability of the information presented during the preview.
 
 
 IPFS relies on the coordinated participation of a swarm of independent peers to function correctly. Therefore, measuring the performance and health of the network is crucial for ensuring its reliability and efficiency. In this context, we summarise a number of network characteristics as key performance indicators. 
-Our KPIs are currently focusing primarily on the public [IPFS DHT](https://docs.ipfs.tech/concepts/dht/) (although we do report on other parts of the architecture too). Understanding that IPFS is an ecosystem of content routing subsystems, over time, we plan to expand to other content routing subsystems too.
+Our KPIs are currently focusing primarily on the public [IPFS DHT](https://docs.ipfs.tech/concepts/dht/) (although we do report on other parts of the architecture too). Understanding that IPFS is an ecosystem of [content routing subsystems](https://docs.ipfs.tech/concepts/how-ipfs-works/#subsystems-overview), over time, we plan to expand to other content routing subsystems too.
 
 ## Network Size & Stability
 

--- a/content.en/ipfskpi/_index.md
+++ b/content.en/ipfskpi/_index.md
@@ -13,23 +13,23 @@ the completeness or reliability of the information presented during the preview.
 
 
 IPFS relies on the coordinated participation of a swarm of independent peers to function correctly. Therefore, measuring the performance and health of the network is crucial for ensuring its reliability and efficiency. In this context, we summarise a number of network characteristics as key performance indicators. 
-Our KPIs are currently focusing primarily on the public IPFS DHT (although we do report on other parts of the architecture too). Understanding that IPFS is an ecosystem of content routing subsystems, over time, we plan to expand to other content routing subsystems too.
+Our KPIs are currently focusing primarily on the public [IPFS DHT](https://docs.ipfs.tech/concepts/dht/) (although we do report on other parts of the architecture too). Understanding that IPFS is an ecosystem of content routing subsystems, over time, we plan to expand to other content routing subsystems too.
 
 ## Network Size & Stability
 
 ### Client vs Server Node Estimate
 
-The total number of peers in the network is estimated using the number of unique peer IDs seen by Protocol Labs' bootstrap nodes. The number of unique DHT Server peer IDs identified by the Nebula crawler is then subtracted from the total number of peers (seen by the bootstrappers) to estimate the number of peers that exclusively function as DHT Clients.
+The total number of peers in the network is estimated using the number of unique [Peer IDs](https://docs.ipfs.tech/concepts/glossary/#peer-id) seen by Protocol Labs' [bootstrap nodes](https://docs.ipfs.tech/concepts/glossary/#bootstrap-node). The number of unique [DHT Server](https://docs.ipfs.tech/concepts/dht/#routing-tables) peer IDs identified by the [Nebula crawler](https://github.com/dennis-tra/nebula) is then subtracted from the total number of peers (seen by the bootstrappers) to estimate the number of peers that exclusively function as DHT Clients.
 
 {{< plotly json="../../plots/latest/ipfs-servers-vs-clients.json" height="400px" >}}
 
 ## Content Routing 
 
-IPFS employs several content routing subsystems, with the Kademlia Distributed Hash Table (DHT) being the most established. Within the network, peers commonly use this system to locate other peers that hold the content being requested. We measure the availability of DHT server nodes and the latency of DHT lookups for random content.
+IPFS employs several content routing subsystems, with the [Kademlia](https://docs.ipfs.tech/concepts/dht/#kademlia) Distributed Hash Table (DHT) being the most established. Within the network, peers commonly use this system to locate other peers that hold the content being requested. We measure the availability of DHT server nodes and the latency of [DHT lookups](https://docs.ipfs.tech/concepts/dht/#lookup-algorithm) for random content.
 
 ### DHT server availability
 
-We categorize DHT Server nodes with regard to their "availability" as follows:
+We categorize [DHT Server](https://docs.ipfs.tech/concepts/dht/#routing-tables) nodes with regard to their "availability" as follows:
 - "Online": the node has been found online for 80% of time or more.
 - "Mostly Online": the node has been found online between 40%-80% of time.
 - "Mostly Offline": the node has been found online between 10%-40% of time.
@@ -41,8 +41,8 @@ We categorize DHT Server nodes with regard to their "availability" as follows:
 
 ### DHT Lookup performance
 
-We have instrumented the following experiment to capture the DHT Lookup performance over time and from several different geographic locations.
-We have set up IPFS DHT Server nodes in seven (7) different geographic locations. Each node periodically publishes a unique CID and makes it known to the rest of the nodes, who subsequently request it through the DHT (acting as clients). This way we capture the DHT Lookup performance from each location.
+We have instrumented the following experiment to capture the [DHT Lookup](https://docs.ipfs.tech/concepts/dht/#lookup-algorithm) performance over time and from several different geographic locations.
+We have set up IPFS DHT Server nodes in seven (7) different geographic locations. Each node periodically publishes a unique [Content Identifier (CID)](https://docs.ipfs.tech/concepts/content-addressing/#content-identifiers-cids) and makes it known to the rest of the nodes, who subsequently request it through the DHT (acting as clients). This way we capture the DHT Lookup performance from each location.
 In this section we present the average performance over all regions.
 
 {{< plotly json="../../plots/latest/dht-lookup-performance-quartiles.json" height="250px" >}}
@@ -51,18 +51,18 @@ In this section we present the average performance over all regions.
 
 ### IPNI utilization
 
-IPNI is a set of protocols that describe how data can be indexed across the IPFS and Filecoin networks. Network indexers complement the IPFS DHT to enable peers to locate content-addressed data. The data in the plot below shows the number of requests made per day to the network indexers operated by cid.contact.
+[IPNI](https://github.com/ipni) is a set of protocols that describe how data can be indexed across the IPFS and Filecoin networks. Network indexers complement the [IPFS DHT](https://docs.ipfs.tech/concepts/dht/) to enable peers to locate content-addressed data. The data in the plot below shows the number of requests made per day to the network indexers operated by [cid.contact](https://cid.contact/).
 
 {{< plotly json="../../plots/latest/ipni-requests-overall.json" height="600px" >}}
 
 
 ## Websites and Traffic
 
-A common use-case for IPFS is hosting websites, addressed using IPNS or DNSLink. We monitor the time it takes to load sample websites through a browser and the number of requests to the public Protocol Labs operated IPFS gateways. 
+A common use-case for IPFS is hosting websites, addressed using [IPNS](https://docs.ipfs.tech/concepts/dht/) or [DNSLink](https://docs.ipfs.tech/concepts/dnslink/). We monitor the time it takes to load sample websites through a browser and the number of requests to the public Protocol Labs operated [IPFS gateways](https://docs.ipfs.tech/concepts/ipfs-gateway/). 
 
 {{< plotly json="../../plots/latest/websites-ttfb-quartiles.json" height="250px" >}}
 
-The following plot shows the total number of requests made per day to the public IPFS gateways operated by Protocol Labs (ipfs.io and dweb.link).
+The following plot shows the total number of requests made per day to the [public IPFS gateways](https://docs.ipfs.tech/concepts/ipfs-gateway/#gateway-providers) operated by Protocol Labs (ipfs.io and dweb.link).
 
 {{< plotly json="../../plots/latest/gateway-requests-overall.json" height="600px" >}}
 


### PR DESCRIPTION
Adding links to other IPFS-related sites, like docs etc. Not sure I have overdone it with adding repeatedly links for the same concepts. Feel free to ignore/remove some of them.