### PR TITLE
website performance gauge add misisng where clause

### DIFF
--- a/config/plotdefs-website/website-snapshot-performance-gauge.yaml
+++ b/config/plotdefs-website/website-snapshot-performance-gauge.yaml
@@ -24,6 +24,7 @@ datasets:
         and m.created_at < {{ .StartOfWeek | timestamptz }}
         and m.website = '{{ .Params.website }}'
         and m.type = '{{ .Params.type }}'
+        and m.ttfb is not null
   - name: "previous"
     source: "tiros"
     query: >


### PR DESCRIPTION
The comparison between previous and current date ranges wasn't fair because we were not filtering correctly