### PR TITLE
Adding page views link

### DIFF
--- a/content.en/about/_index.md
+++ b/content.en/about/_index.md
@@ -1,5 +1,5 @@
 ---
-title: About
+title: About & Contact
 weight: 210
 plotly: false
 hidetoc: true
@@ -19,6 +19,8 @@ This is a space where we present results from our measurement and monitoring eff
 The results presented here give an accurate view of the high-level protocol operation and occasionally dive into protocol specific parameters that are primarily of interest to protocol designers and engineers. What is different about this website is that it is not a “raw” dashboard, but instead includes description of the experiments we’re carrying out in order to produce the results. Where possible, we also make the tools used to produce the results available to the community to re-use.
 
 We do not provide commentary on the results presented on this website. Instead, discussion around results reported here is taking place at the [IPFS Discussion Forum](https://discuss.ipfs.tech/), under the “Testing & Experiments” category and the “Measurements” tab. We occasionally write blogposts (primarily in the [IPFS blog](https://blog.ipfs.tech) and technical reports, which we link from the “News” tab on this site.
+
+Page views of this website can be found at: [https://plausible.io/probelab.io](https://plausible.io/probelab.io).
 
 ## Contact
 


### PR DESCRIPTION
Adding the plausible analytics to show the page views: https://plausible.io/probelab.io. I'm not sure if this is the best place to add it, but couldn't find a better one.

Also tweaked the title of the section to point to "Contact" as well.