### PR TITLE
add stable providers graph to probelab.io

### DIFF
--- a/content.en/websites/probelab.io.md
+++ b/content.en/websites/probelab.io.md
@@ -11,7 +11,7 @@ We initially present an Overview of the performance, followed by Trends, i.e., t
 
 ## Overview
 
-### General Performance {#website-snapshot-performance-gauge-probelabio-kubo}
+### Performance over Kubo {#website-snapshot-performance-gauge-probelabio-kubo}
 
 {{< plotly json="../../plots/latest/website-snapshot-performance-gauge-probelab.io-KUBO.json" height="300px" >}}
 
@@ -55,6 +55,14 @@ In order for a website (or CID more in general) to be available and accessible i
 
 In addition to the peer-related information, the graph also includes black markers that represent the number of website deployments per day (count shown on the right handside y-axis).
 Deployments are determined by monitoring the CIDs found within the websites' IPNS records. If the CID changes, we consider this a new deployment.
+
+#### Known Stable Providers {#website-trend-hosters-probelabio}
+
+{{< plotly json="../../plots/latest/website-trend-hosters-probelab.io.json" height="250px" >}}
+
+For the above graph, we obtained the PeerIDs from two hosting providers/pinning services: [Protocol Labs' IPFS Websites Collab-Cluster](https://collab.ipfscluster.io/) and [Fleek](https://fleek.co). We monitor how many of their PeerIDs appear in the list of peers providing the website to the DHT on a daily basis. We gather the list of providing peers every six hours from seven different vantage points with two different Kubo versions (see [Tiros](/tools/tiros)), and aggregate the distinct peers we have found. Then we count the number of peerIDs that belong to either Fleek or PL's Collab-Cluster. We monitor six PeerIDs for Fleek and seven PeerIDs for PL's Collab-Cluster. The sum of both bars should always be less than or equal to the number of `Reachable Non-Relayed` peers in the previous graph.
+
+More importantly, if both bars (for Fleek and the PL Cluster) are at zero, then this very likely means that the website has no stable providers on the IPFS DHT.
 
 ### IPFS Retrieval Errors {#website-trend-retrieval-errors-probelabio-kubo}
 


### PR DESCRIPTION
**Changelog**

- reran template generator 👍 
- the missing stable providers graph was missing for `probelab.io`