### PR TITLE
parsec description tiny update

### DIFF
--- a/content.en/tools/_index.md
+++ b/content.en/tools/_index.md
@@ -15,8 +15,7 @@ ProbeLab is running multiple sets of experiments that aim to push the boundaries
 
 ## Parsec
 
-Another tool that ProbeLab has developed is
-called [`parsec`](https://github.com/plprobelab/parsec). Parsec is a DHT lookup performance measurement tool that is used to gather accurate data on the performance of DHT lookups and publications. `parsec`-based experiments are aimed at improving the efficiency and speed of distributed systems by developing better algorithms for routing and data retrieval.
+[`parsec`](https://github.com/plprobelab/parsec) is a DHT and IPNI performance measurement tool that is used to gather accurate data on the performance of DHT and IPNI lookups and publications. `parsec`-based experiments are aimed at improving the efficiency and speed of distributed systems by developing better algorithms for routing and data retrieval.
 
 {{< button relref="/parsec" >}}Learn more{{< /button >}}
 


### PR DESCRIPTION
Adding that it's now for IPNI as well, instead of DHT only. I see that in the main page description (https://probelab.io/tools/parsec/) it is updated. We're mentioning both lookups and publications, although AFAIU we're using it for lookups only. If that's too heavy an inconsistency, @dennis-tra let's rephrase accordingly. Leaving it up to you to decide :) 