### PR TITLE
Update tab title for website monitoring

### DIFF
--- a/content.en/websites/_index.md
+++ b/content.en/websites/_index.md
@@ -1,5 +1,5 @@
 ---
-title: IPFS Websites
+title: Website Monitoring
 bookCollapseSection: true
 plotly: true
 weight: 40


### PR DESCRIPTION
The current title of the tab on left hand side says "IPFS Websites", which reads like this is something for the website(s) of IPFS (e.g., ipfs.io, or something) :-D I thought we can make it clearer that what's there is about monitoring of websites (hosted on IPFS), although it becomes too long if we add the text inside the parenthesis too. Another idea could be to have "Websites on IPFS".

I'm not sure this preamble is the only place that needs changing, leaving this to @dennis-tra :) 