### PR TITLE
fix kubo version parsing

### DIFF
--- a/config/plotdefs/kubo-version-distribution.yaml
+++ b/config/plotdefs/kubo-version-distribution.yaml
@@ -18,7 +18,7 @@ datasets:
               end
               end as agent,
              case
-            when position('@' in agent_version) = 0 then split_part(split_part(agent_version, '/',2), '-',1)
+            when position('@' in agent_version) = 0 then substring(agent_version from 'kubo\/[0-9]+\.([0-9]+)\.[0-9]+.*')
             else split_part(agent_version, '@',2)
              end as version
         from agent_versions

--- a/config/plotdefs/kubo-version-distribution.yaml
+++ b/config/plotdefs/kubo-version-distribution.yaml
@@ -32,7 +32,7 @@ datasets:
                 AND v.type = 'crawl' AND v.connect_error IS NULL
                 and (av.agent = 'go-ipfs' or av.agent = 'kubo')
         group by av.agent, av.version
-        order by cast(split_part(av.version, '.',1) as numeric)*10000+cast(split_part(av.version, '.',2) as numeric)*100+cast(split_part(av.version, '.',3) as numeric);
+        order by cast(coalesce(nullif(split_part(av.version, '.',1),''),'0') as numeric)*10000+cast(coalesce(nullif(split_part(av.version, '.',2),''),'0') as numeric)*100+cast(coalesce(nullif(split_part(av.version, '.',3),''),'0') as numeric);
 
 series:
   - type: "hbar"

--- a/config/plotdefs/recent-kubo-versions-over-time.yaml
+++ b/config/plotdefs/recent-kubo-versions-over-time.yaml
@@ -19,7 +19,7 @@ datasets:
                 end
                 end as agent,
                case
-              when position('@' in agent_version) = 0 then split_part(split_part(agent_version, '/',2), '-',1)
+              when position('@' in agent_version) = 0 then substring(agent_version from 'kubo\/[0-9]+\.([0-9]+)\.[0-9]+.*')
               else split_part(agent_version, '@',2)
                end as version
           from agent_versions
@@ -36,7 +36,7 @@ datasets:
                   AND v.type = 'crawl' AND v.connect_error IS NULL
                   and (av.agent = 'go-ipfs' or av.agent = 'kubo')
           group by period.start, av.agent, av.version
-          order by period.start, cast(split_part(av.version, '.',1) as numeric)*10000+cast(split_part(av.version, '.',2) as numeric)*100+cast(split_part(av.version, '.',3) as numeric) desc
+          order by period.start, cast(coalesce(nullif(split_part(av.version, '.',1),''),'0') as numeric)*10000+cast(coalesce(nullif(split_part(av.version, '.',2),''),'0') as numeric)*100+cast(coalesce(nullif(split_part(av.version, '.',3),''),'0') as numeric) desc
       )
       select start+'1 week'::interval as date, case when rank<=9 then agentversion else 'all others' end as version, sum(number) as number, max(rank) as rank
       from kubos


### PR DESCRIPTION
@iand noticed the following error when running ashby:
```
processing plot definitions: failed to generate plot "kubo-version-distribution": failed to get dataset from source "nebula_ipfs": collect rows: ERROR: invalid input syntax for type numeric: "ceramic" (SQLSTATE 22P02)
```

turns out, ceramic uses the following agent versions:

<img width="1025" alt="Screenshot 2023-08-21 at 13 12 08" src="https://github.com/plprobelab/website/assets/11836793/2968d6fd-a00f-41ff-b9d0-4ae45aaaf033">

This PR attempts to improve the kubo agent version parsing