### PR TITLE
Use caracol collections based on nginx_http_response_codes_total for gateway plots

### DIFF
--- a/config/plotdefs/gateway-requests-daily.yaml
+++ b/config/plotdefs/gateway-requests-daily.yaml
@@ -3,7 +3,7 @@ datasets:
   - name: "Bifrost total requests by day"
     source: "caracol"
     query: >
-      select date, value from get_collected_values(4, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
+      select date, value from get_collected_values(19, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
 
 series:
   - type: "bar"

--- a/config/plotdefs/gateway-requests-overall.yaml
+++ b/config/plotdefs/gateway-requests-overall.yaml
@@ -3,7 +3,7 @@ datasets:
   - name: "Bifrost total requests by day"
     source: "caracol"
     query: >
-      select date, value from get_collected_values(4, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
+      select date, value from get_collected_values(19, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
 
 series:
   - type: "bar"

--- a/config/plotdefs/gateway-requests-region.yaml
+++ b/config/plotdefs/gateway-requests-region.yaml
@@ -3,19 +3,19 @@ datasets:
   - name: "europe"
     source: "caracol"
     query: >
-      select date, value from get_collected_values(5, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
+      select date, value from get_collected_values(13, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
   - name: "asia se"
     source: "caracol"
     query: >
-      select date, value from get_collected_values(6, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
+      select date, value from get_collected_values(14, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
   - name: "na east"
     source: "caracol"
     query: >
-      select date, value from get_collected_values(7, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
+      select date, value from get_collected_values(15, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
   - name: "na west"
     source: "caracol"
     query: >
-      select date, value from get_collected_values(8, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
+      select date, value from get_collected_values(16, {{ .StartOfDay | timestamptz }} - '90 day'::interval, {{ .StartOfDay | timestamptz }});
 
 series:
   - type: "bar"


### PR DESCRIPTION
The `nginx_http_requests_total` metric is no longer available in the bifrost prometheus instance. We were using this metric for the `"Gateway total requests by day` and `Gateway total requests by region` plots using some underlying caracol sequences (ids 4, 5,6,7 and 8). However we also has some equivalent sequences in caracol that were based on the `nginx_http_response_codes_total` metric. I switched the regional plots to use the existing caracol collections and created a new one for the total number of requests using:

```
caracol query add --dburl $PG_CARACOL_WRITE 
                  --name "bifrost-prometheus; nginx_http_response_codes_total; gateways; all families; all regions" 
                  --source-id 2 
                  --query-type="prometheus" 
                  --interval daily 
                  --start 2023-06-01T00:00:00Z 
                  --query 'ceil(sum(increase(nginx_http_response_codes_total{job="gateways_mtail", family=~"api|ipfs|ipns|refs"}[1d])))' 
```

I also stopped the failing caracol queries (which were alering) from being populated by setting their finish time to  2023-10-24T00:00:00Z which preserves the data already collected up to that date:

```
caracol query finish --dburl $PG_CARACOL_WRITE  --id 4 --finish 2023-10-24T00:00:00Z
caracol query finish --dburl $PG_CARACOL_WRITE  --id 5 --finish 2023-10-24T00:00:00Z
caracol query finish --dburl $PG_CARACOL_WRITE  --id 6 --finish 2023-10-24T00:00:00Z
caracol query finish --dburl $PG_CARACOL_WRITE  --id 7 --finish 2023-10-24T00:00:00Z
caracol query finish --dburl $PG_CARACOL_WRITE  --id 8 --finish 2023-10-24T00:00:00Z
```